### PR TITLE
Now works with certificates that are not marked as exportable

### DIFF
--- a/AzureEncryptionExtensions/AzureEncryptionExtensions.csproj
+++ b/AzureEncryptionExtensions/AzureEncryptionExtensions.csproj
@@ -68,6 +68,12 @@
   <ItemGroup>
     <Compile Include="BlobExtensions.cs" />
     <Compile Include="ConcatenatedStream.cs" />
+    <Compile Include="Crypto\CspProxy.cs" />
+    <Compile Include="Crypto\CspProxyFactory.cs" />
+    <Compile Include="Crypto\DisposingCspProxy.cs" />
+    <Compile Include="Crypto\ICspProxy.cs" />
+    <Compile Include="Crypto\ICspProxyFactory.cs" />
+    <Compile Include="Crypto\NonDisposingCspProxy.cs" />
     <Compile Include="Exceptions.cs" />
     <Compile Include="KeyFileStorage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/AzureEncryptionExtensions/AzureEncryptionExtensions.nuspec
+++ b/AzureEncryptionExtensions/AzureEncryptionExtensions.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>AzureEncryptionExtensions</id>
-    <version>1.0.0.1</version>
+    <version>1.0.1.0</version>
     <title>Azure Encryption Extensions</title>
     <authors>Stefan Gordon</authors>
     <owners>Stefan Gordon</owners>

--- a/AzureEncryptionExtensions/Crypto/CspProxy.cs
+++ b/AzureEncryptionExtensions/Crypto/CspProxy.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzureEncryptionExtensions.Crypto
+{
+    internal abstract class CspProxy : ICspProxy
+    {
+        protected readonly RSACryptoServiceProvider Rsa;
+
+        public byte[] KeyBlob
+        {
+            get 
+            {
+                if (IsPublicOnly) return PublicKeyBlob;
+                if (!IsExportable) throw new InvalidOperationException("Key cannot be exported.");
+                return Rsa.ExportCspBlob(true);
+            }
+        }
+
+        public byte[] PublicKeyBlob
+        {
+            get 
+            {
+                return Rsa.ExportCspBlob(false);
+            }
+        }
+
+        public bool IsPublicOnly
+        {
+            get { return Rsa.PublicOnly; }
+        }
+
+        public bool IsExportable
+        {
+            get 
+            {
+                // If the key container is not accessible, then this provider was generated
+                // dynamically and should always have the key available
+                return Rsa.CspKeyContainerInfo.Accessible ?
+                    Rsa.CspKeyContainerInfo.Exportable :
+                    true;
+            }
+        }
+
+        public int AsymmetricKeySize
+        {
+            get;
+            private set;
+        }
+
+        public CspProxy(RSACryptoServiceProvider rsa, int keySize)
+        {
+            Rsa = rsa;
+            AsymmetricKeySize = keySize;
+        }
+
+        public byte[] Encrypt(byte[] value)
+        {
+            return Rsa.Encrypt(value, false);
+        }
+
+        public byte[] Decrypt(byte[] encrypted)
+        {
+            if (IsPublicOnly)
+            {
+                throw new CryptographicProviderException(
+                        "Unable to decrypt data because the private key is not available. " +
+                        "Please instantiate an AsymmetricBlobCryptoProvider with a valid private key.");
+            }
+
+            return Rsa.Decrypt(encrypted, false);
+        }
+
+        public abstract void Dispose();
+    }
+}

--- a/AzureEncryptionExtensions/Crypto/CspProxyFactory.cs
+++ b/AzureEncryptionExtensions/Crypto/CspProxyFactory.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzureEncryptionExtensions.Crypto
+{
+    internal class CspProxyFactory
+    {
+        private class DefaultFactory : ICspProxyFactory
+        {
+            private readonly byte[] CspBlob;
+            private readonly int KeySize;
+
+            public DefaultFactory(byte[] cspBlob, int keySize)
+            {
+                CspBlob = cspBlob;
+                KeySize = keySize;
+            }
+
+            public ICspProxy GetProvider()
+            {
+                RSACryptoServiceProvider rsa = new RSACryptoServiceProvider();
+                rsa.ImportCspBlob(CspBlob);
+
+                return new DisposingCspProxy(rsa, KeySize);
+            }
+        }
+
+        private class CachingFactory : ICspProxyFactory
+        {
+            private readonly RSACryptoServiceProvider Rsa;
+            private readonly int KeySize;
+
+            public CachingFactory(RSACryptoServiceProvider rsa)
+            {
+                Rsa = rsa;
+                KeySize = rsa.KeySize;
+            }
+
+            public ICspProxy GetProvider()
+            {
+                // This CSP has to survive so that it can be used again
+                return new NonDisposingCspProxy(Rsa, KeySize);
+            }
+        }
+
+        public static ICspProxyFactory Create(int keySize)
+        {
+            using (RSACryptoServiceProvider rsa = new RSACryptoServiceProvider(keySize))
+            {
+                return new DefaultFactory(rsa.ExportCspBlob(true), rsa.KeySize);
+            }
+        }
+
+        public static ICspProxyFactory Create(byte[] cspBlob)
+        {
+            using (RSACryptoServiceProvider rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportCspBlob(cspBlob);
+                return new DefaultFactory(cspBlob, rsa.KeySize);
+            }
+        }
+
+        public static ICspProxyFactory Create(X509Certificate2 certificate, bool includePrivateKey)
+        {
+            ICspProxyFactory factory;
+            RSACryptoServiceProvider rsa;
+
+            if (includePrivateKey && certificate.HasPrivateKey)
+                rsa = (RSACryptoServiceProvider)certificate.PrivateKey;
+            else
+                rsa = (RSACryptoServiceProvider)certificate.PublicKey.Key;
+
+            // Export will fail if we attempt to export private when there is none
+            // Export also fails if key is not exportable
+            if (rsa.PublicOnly)
+            {
+                factory = new DefaultFactory(rsa.ExportCspBlob(false), rsa.KeySize);
+                rsa.Dispose();
+            }
+            else if (rsa.CspKeyContainerInfo.Exportable)
+            {
+                factory = new DefaultFactory(rsa.ExportCspBlob(true), rsa.KeySize);
+                rsa.Dispose();
+            }
+            else
+            {
+                factory = new CachingFactory(rsa);
+            }
+
+            return factory;
+        }
+    }
+}

--- a/AzureEncryptionExtensions/Crypto/DisposingCspProxy.cs
+++ b/AzureEncryptionExtensions/Crypto/DisposingCspProxy.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzureEncryptionExtensions.Crypto
+{
+    internal class DisposingCspProxy : CspProxy
+    {
+        public DisposingCspProxy(RSACryptoServiceProvider rsa, int keySize)
+            : base(rsa, keySize)
+        {
+        }
+
+        public override void Dispose()
+        {
+            Rsa.Dispose();
+        }
+    }
+}

--- a/AzureEncryptionExtensions/Crypto/ICspProxy.cs
+++ b/AzureEncryptionExtensions/Crypto/ICspProxy.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzureEncryptionExtensions.Crypto
+{
+    internal interface ICspProxy : IDisposable
+    {
+        byte[] KeyBlob { get; }
+        byte[] PublicKeyBlob { get; }
+        bool IsPublicOnly { get; }
+        int AsymmetricKeySize { get; }
+
+        byte[] Encrypt(byte[] value);
+        byte[] Decrypt(byte[] encrypted);
+    }
+}

--- a/AzureEncryptionExtensions/Crypto/ICspProxyFactory.cs
+++ b/AzureEncryptionExtensions/Crypto/ICspProxyFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzureEncryptionExtensions.Crypto
+{
+    internal interface ICspProxyFactory
+    {
+        ICspProxy GetProvider();
+    }
+}

--- a/AzureEncryptionExtensions/Crypto/NonDisposingCspProxy.cs
+++ b/AzureEncryptionExtensions/Crypto/NonDisposingCspProxy.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzureEncryptionExtensions.Crypto
+{
+    internal class NonDisposingCspProxy : CspProxy
+    {
+        public NonDisposingCspProxy(RSACryptoServiceProvider rsa, int keySize)
+            : base(rsa, keySize)
+        {
+        }
+
+        public override void Dispose()
+        {
+        }
+    }
+}

--- a/AzureEncryptionExtensions/Properties/AssemblyInfo.cs
+++ b/AzureEncryptionExtensions/Properties/AssemblyInfo.cs
@@ -32,5 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.1")]
-[assembly: AssemblyFileVersion("1.0.0.1")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]
+
+[assembly: InternalsVisibleTo("AzureEncryptionExtensionsTests")]


### PR DESCRIPTION
Azure does not allow exportable certificates to be created on Web/Worker roles (see: http://stackoverflow.com/questions/8175860/accessing-private-keys-from-certificate-deployed-to-windows-azure/15337286#15337286). This fix allows those certificates to be used for encryption. 

For the most part, the pattern of extracting the CSP blob has been maintained, and RSA CSP providers are disposed after use. If a certificate is not exportable, it will create a CSP provider that is reused for the lifetime of the provider. 